### PR TITLE
Add missing CSP directives

### DIFF
--- a/lib/yaml_csp_config/yaml_loader.rb
+++ b/lib/yaml_csp_config/yaml_loader.rb
@@ -32,7 +32,6 @@ module YamlCspConfig
       style_src_attr
       style_src_elem
       trusted_types
-      unsafe_hashes
       upgrade_insecure_requests
       worker_src
     ].freeze

--- a/lib/yaml_csp_config/yaml_loader.rb
+++ b/lib/yaml_csp_config/yaml_loader.rb
@@ -5,6 +5,7 @@ module YamlCspConfig
   class YamlLoader
     DIRECTIVES = %i[
       base_uri
+      block_all_mixed_content
       child_src
       connect_src
       default_src
@@ -15,10 +16,24 @@ module YamlCspConfig
       img_src
       manifest_src
       media_src
+      navigate_to
       object_src
+      plugin_types
       prefetch_src
+      referrer
+      report_to
+      report_uri
+      require_trusted_types_for
+      sandbox
       script_src
+      script_src_attr
+      script_src_elem
       style_src
+      style_src_attr
+      style_src_elem
+      trusted_types
+      unsafe_hashes
+      upgrade_insecure_requests
       worker_src
     ].freeze
 


### PR DESCRIPTION
Added missing CSP directives (the simple way) listed in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy as mentioned in #2.

Ran the test suite and everything passed. Please let me know if there is anything that can be done,